### PR TITLE
Delete user entry with id 97 from testfile

### DIFF
--- a/testfile
+++ b/testfile
@@ -19,24 +19,6 @@ hello
   }
 }
 {
-  "id": 97,
-  "firstName": "Sophia",
-  "lastName": "Harris",
-  "email": "hwkns@45zyl.com",
-  "active": true,
-  "tags": [
-    "part"
-  ],
-  "details": {
-    "age": 51,
-    "city": "Lahore",
-    "country": "Spain",
-    "phoneNumber": "(214) 672-3493",
-    "startDate": "2000-12-20T13:20:47.799Z",
-    "endDate": "2013-04-29T04:56:50.656Z"
-  }
-}
-{
   "id": 86,
   "firstName": "Michael",
   "lastName": "Wood",


### PR DESCRIPTION
This pull request makes a small change by removing a user entry from the `hello` object in the `testfile`. No other functionality or structure is affected. Removed a user entry with id 97 from the test data.