### PR TITLE
Add new user records to testfile

### DIFF
--- a/testfile
+++ b/testfile
@@ -221,3 +221,44 @@ hello
     "endDate": "2007-02-07T09:58:17.304Z"
   }
 }
+
+{
+  "id": 82,
+  "firstName": "Amelia",
+  "lastName": "Reynolds",
+  "email": "8t8y6@72brl.com",
+  "active": true,
+  "tags": [
+    "state",
+    "boat",
+    "board",
+    "part",
+    "job"
+  ],
+  "details": {
+    "age": 95,
+    "city": "Rio de Janeiro",
+    "country": "Russia",
+    "phoneNumber": "(602) 310-4039",
+    "startDate": "2009-08-02T15:45:43.382Z",
+    "endDate": "2007-09-05T07:19:57.857Z"
+  }
+}
+{
+  "id": 24,
+  "firstName": "Elizabeth",
+  "lastName": "Wood",
+  "email": "qltxh@uakyd.com",
+  "active": false,
+  "tags": [
+    "ability"
+  ],
+  "details": {
+    "age": 86,
+    "city": "Paris",
+    "country": "Colombia",
+    "phoneNumber": "(718) 382-9158",
+    "startDate": "2017-01-23T04:20:14.255Z",
+    "endDate": "2024-11-08T10:02:17.171Z"
+  }
+}


### PR DESCRIPTION
This pull request adds two new user records to the `hello` section in `testfile`, each with detailed profile information including personal details, contact info, and tags.

Data additions:

* Added a new user record for "Amelia Reynolds" with fields such as `id`, `firstName`, `lastName`, `email`, `active`, `tags`, and a nested `details` object containing age, city, country, phone number, and date fields.
* Added a new user record for "Elizabeth Wood" with similar fields and structure as above.